### PR TITLE
Add simple subtitle translation training setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.so
+*.dylib
+
+# Data and model artifacts
+model/
+*.ckpt
+*.pt
+*.bin
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# codex_test
+# Subtitle Translation Training
+
+This repository contains a simple example of how to fine-tune a machine translation model for TV subtitles using [Hugging Face Transformers](https://huggingface.co/transformers/).
+
+## Quickstart
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Prepare your dataset in CSV format with the columns `source` and `target`. A tiny example is provided in the `data/` directory.
+
+3. Run training:
+   ```bash
+   python scripts/train.py \
+       --train_file data/train.csv \
+       --valid_file data/val.csv \
+       --model_name Helsinki-NLP/opus-mt-zh-en \
+       --output_dir model
+   ```
+
+The script will fine-tune the specified model and save it to the `model/` directory.

--- a/data/train.csv
+++ b/data/train.csv
@@ -1,0 +1,3 @@
+source,target
+你好世界,Hello world
+早上好,Good morning

--- a/data/val.csv
+++ b/data/val.csv
@@ -1,0 +1,2 @@
+source,target
+谢谢,Thank you

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+torch
+transformers
+datasets
+sentencepiece

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,0 +1,67 @@
+import argparse
+from datasets import load_dataset
+from transformers import (AutoTokenizer, AutoModelForSeq2SeqLM,
+                          DataCollatorForSeq2Seq, Seq2SeqTrainingArguments,
+                          Seq2SeqTrainer)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train a translation model for subtitles")
+    parser.add_argument('--train_file', type=str, default='data/train.csv',
+                        help='Path to training CSV file with columns source,target')
+    parser.add_argument('--valid_file', type=str, default='data/val.csv',
+                        help='Path to validation CSV file with columns source,target')
+    parser.add_argument('--model_name', type=str, default='Helsinki-NLP/opus-mt-zh-en',
+                        help='Pretrained model name or path')
+    parser.add_argument('--output_dir', type=str, default='model', help='Where to store the trained model')
+    parser.add_argument('--num_train_epochs', type=int, default=3)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    data_files = {'train': args.train_file, 'validation': args.valid_file}
+    dataset = load_dataset('csv', data_files=data_files)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    model = AutoModelForSeq2SeqLM.from_pretrained(args.model_name)
+
+    def preprocess(example):
+        inputs = tokenizer(example['source'], truncation=True)
+        targets = tokenizer(example['target'], truncation=True)
+        example['input_ids'] = inputs['input_ids']
+        example['attention_mask'] = inputs['attention_mask']
+        example['labels'] = targets['input_ids']
+        return example
+
+    tokenized = dataset.map(preprocess, batched=True)
+
+    data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)
+
+    training_args = Seq2SeqTrainingArguments(
+        output_dir=args.output_dir,
+        per_device_train_batch_size=4,
+        per_device_eval_batch_size=4,
+        evaluation_strategy='epoch',
+        save_strategy='epoch',
+        num_train_epochs=args.num_train_epochs,
+        predict_with_generate=True,
+        logging_dir='logs'
+    )
+
+    trainer = Seq2SeqTrainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized['train'],
+        eval_dataset=tokenized['validation'],
+        tokenizer=tokenizer,
+        data_collator=data_collator
+    )
+
+    trainer.train()
+    trainer.save_model(args.output_dir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `.gitignore` for Python and model artifacts
- add sample training and validation CSVs
- add a minimal translation training script
- add package requirements
- document usage in README

## Testing
- `python3 -m py_compile scripts/train.py`

------
https://chatgpt.com/codex/tasks/task_e_68484b7e74588329b7572494595f9de8